### PR TITLE
Route ping method to correct endpoint

### DIFF
--- a/con.js
+++ b/con.js
@@ -65,7 +65,7 @@ class Connection extends EventEmitter {
       console.log(new Date, '[DERIBIT] NO PING RESPONSE');
       this.terminate();
     }, 10000)
-    await this.request('/public/test');
+    await this.request('public/test');
     clearInterval(timeout);
   }
 


### PR DESCRIPTION
current request does
```
{ jsonrpc: '2.0',
  method: '/public/test',
  params: undefined,
  id:  1566036911166}
```
which gets this response 
```
{ jsonrpc: '2.0',
  id: 1566036911166,
  error: { message: 'Method not found', code: -32601 },
  testnet: true,
  usIn: 1566036912096038,
  usOut: 1566036912096279,
  usDiff: 241 }
```
