### PR TITLE
Testnet Parameter

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -4,7 +4,8 @@ const EventEmitter = require('events');
 const wait = n => new Promise(r => setTimeout(r, n));
 
 class Connection extends EventEmitter {
-  constructor({key, secret, domain = 'www.deribit.com'}) {
+  constructor({key, secret, domain}) {
+    if(domain==null){domain = 'www.deribit.com'}
     super();
 
     this.key = key;


### PR DESCRIPTION
Can build API object for the testapp URL instead of always defaulting to mainnet.