### PR TITLE
fix exponential subscription

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -277,7 +277,7 @@ class Connection extends EventEmitter {
 
   subscribe = (type, channel) => {
 
-    if(this.subscriptions.find(s => s.type == type && s.channel == channel) === undefined)
+    if(!this.subscriptions.find(s => s.type == type && s.channel == channel))
       this.subscriptions.push({type, channel});
 
     if(!this.connected) {

--- a/connection.js
+++ b/connection.js
@@ -277,7 +277,8 @@ class Connection extends EventEmitter {
 
   subscribe = (type, channel) => {
 
-    this.subscriptions.push({type, channel});
+    if(this.subscriptions.find(s => s.type == type && s.channel == channel) === undefined)
+      this.subscriptions.push({type, channel});
 
     if(!this.connected) {
       throw new Error('Not connected.');


### PR DESCRIPTION
When reconnecting, all active subscriptions prior to disconnection are getting re-subscribed : 

https://github.com/askmike/deribit-v2-ws/blob/3a350198b514b4daa1839bc74fa5c26525d3f35f/connection.js#L115-L117

However, notice that they are also getting pushed in the table of subscriptions again : 

https://github.com/askmike/deribit-v2-ws/blob/3a350198b514b4daa1839bc74fa5c26525d3f35f/connection.js#L280

This mean that the number of subscriptions will double every reconnection : `2^(reconnection + subscription - 1)`
For example, with 2 subscriptions and after 5 reconnections you would end up with 64 subscriptions.
This pull request fix this by checking if the subscription is not already in the array of subscription.